### PR TITLE
peewee backend

### DIFF
--- a/flask_potion/backends/peewee.py
+++ b/flask_potion/backends/peewee.py
@@ -214,7 +214,7 @@ class PeeweeManager(Manager):
         try:
             item.save()
         except pw.IntegrityError as e:
-            if 'UNIQUE constraint failed' in str(e):
+            if 'unique constraint' in str(e).lower():
                 raise DuplicateKey(detail=e.message)
             raise BackendConflict()
 
@@ -243,7 +243,7 @@ class PeeweeManager(Manager):
         try:
             item.save()
         except pw.IntegrityError as e:
-            if 'UNIQUE constraint failed' in str(e):
+            if 'unique constraint' in str(e).lower():
                 raise DuplicateKey(detail=e.message)
             raise
 

--- a/flask_potion/backends/peewee.py
+++ b/flask_potion/backends/peewee.py
@@ -72,6 +72,8 @@ class PeeweeManager(Manager):
 
                 if isinstance(column, (pw.CharField, pw.TextField)):
                     field_class = fields.String
+                    if hasattr(column, 'max_length') and column.max_length:
+                        kwargs['max_length'] = column.max_length
                 elif isinstance(column, pw.IntegerField):
                     field_class = fields.Integer
                 elif isinstance(column, (pw.DecimalField, pw.FloatField)):
@@ -82,6 +84,8 @@ class PeeweeManager(Manager):
                     field_class = fields.Date
                 elif isinstance(column, pw.DateTimeField):
                     field_class = fields.Datetime
+                elif isinstance(column, pw.BlobField):
+                    field_class = fields.raw
                 elif isinstance(column, postgres_ext.ArrayField):
                     field_class = fields.Array
                     args = (fields.String,)
@@ -95,9 +99,7 @@ class PeeweeManager(Manager):
                     field_class = fields.Raw
                     kwargs = {"schema": {}}
                 else:
-                    raise RuntimeError(
-                        'No appropriate field class for "{}" found'.format(
-                            column))
+                    field_class = fields.String
 
                 kwargs['nullable'] = column.null
 

--- a/flask_potion/backends/peewee.py
+++ b/flask_potion/backends/peewee.py
@@ -83,7 +83,7 @@ class PeeweeManager(Manager):
                 elif isinstance(column, pw.DateField):
                     field_class = fields.Date
                 elif isinstance(column, pw.DateTimeField):
-                    field_class = fields.Datetime
+                    field_class = fields.DateTime
                 elif isinstance(column, pw.BlobField):
                     field_class = fields.raw
                 elif isinstance(column, postgres_ext.ArrayField):

--- a/flask_potion/backends/peewee.py
+++ b/flask_potion/backends/peewee.py
@@ -214,7 +214,7 @@ class PeeweeManager(Manager):
         try:
             item.save()
         except pw.IntegrityError as e:
-            if 'UNIQUE constraint failed' in e.message:
+            if 'UNIQUE constraint failed' in str(e):
                 raise DuplicateKey(detail=e.message)
             raise BackendConflict()
 
@@ -243,7 +243,7 @@ class PeeweeManager(Manager):
         try:
             item.save()
         except pw.IntegrityError as e:
-            if 'UNIQUE constraint failed' in e.message:
+            if 'UNIQUE constraint failed' in str(e):
                 raise DuplicateKey(detail=e.message)
             raise
 

--- a/flask_potion/backends/peewee.py
+++ b/flask_potion/backends/peewee.py
@@ -1,0 +1,251 @@
+from __future__ import absolute_import
+
+from operator import and_
+
+import peewee as pw
+try:
+    from playhouse import postgres_ext
+except ImportError:
+    postgres_ext = False
+
+from flask_potion import fields, signals
+from flask_potion.backends import Manager
+from flask_potion.exceptions import DuplicateKey, ItemNotFound, BackendConflict
+from flask_potion.utils import get_value
+
+PW_COMPARATOR_EXPRESSIONS = {
+    '$eq': lambda column, value: column == value,
+    '$ne': lambda column, value: column != value,
+    '$in': lambda column, value: column << value,
+    '$lt': lambda column, value: column < value,
+    '$gt': lambda column, value: column > value,
+    '$lte': lambda column, value: column <= value,
+    '$gte': lambda column, value: column >= value,
+    '$contains': lambda column, value: column.contains(value),
+    '$startswith': lambda column, value: column.startswith(value),
+    '$endswith': lambda column, value: column.endswith(value)
+}
+
+
+class PeeweeManager(Manager):
+    """
+    A manager for Peewee models.
+
+    Expects that :class:`Meta.model` contains an SQLALchemy declarative model.
+
+    """
+    supported_comparators = tuple(PW_COMPARATOR_EXPRESSIONS.keys())
+
+    def __init__(self, resource, model):
+        super(PeeweeManager, self).__init__(resource, model)
+
+        meta = resource.meta
+        self.id_attribute = meta.get(
+            'id_attribute', model._meta.primary_key.name)
+
+        if 'id_field' in resource.meta:
+            self.id_column = model._meta.fields[resource.meta.id_field]
+        else:
+            self.id_column = model._meta.primary_key
+
+        if not hasattr(resource.Meta, 'name'):
+            meta['name'] = model._meta.db_table.lower()
+
+        fs = resource.schema
+        include_fields = meta.get('include_fields', None)
+        exclude_fields = meta.get('exclude_fields', None)
+        read_only_fields = meta.get('read_only_fields', ())
+        write_only_fields = meta.get('write_only_fields', ())
+        pre_declared_fields = {f.attribute or k for k, f in fs.fields.items()}
+
+        for name, column in model._meta.get_sorted_fields():
+            if (include_fields and name in include_fields) or \
+                    (exclude_fields and name not in exclude_fields) or \
+                    not (include_fields or exclude_fields):
+                if column.primary_key or \
+                        isinstance(column, pw.ForeignKeyField):
+                    continue
+                if name in pre_declared_fields:
+                    continue
+
+                args = ()
+                kwargs = {}
+
+                if isinstance(column, (pw.CharField, pw.TextField)):
+                    field_class = fields.String
+                elif isinstance(column, pw.IntegerField):
+                    field_class = fields.Integer
+                elif isinstance(column, (pw.DecimalField, pw.FloatField)):
+                    field_class = fields.Number
+                elif isinstance(column, pw.BooleanField):
+                    field_class = fields.Boolean
+                elif isinstance(column, pw.DateField):
+                    field_class = fields.Date
+                elif isinstance(column, pw.DateTimeField):
+                    field_class = fields.Datetime
+                elif isinstance(column, postgres_ext.ArrayField):
+                    field_class = fields.Array
+                    args = (fields.String,)
+                elif isinstance(column, pw.CharField) and column.max_length:
+                    field_class = fields.String
+                    kwargs = {'max_length': column.max_length}
+                elif postgres_ext and \
+                        isinstance(column, postgres_ext.HStoreField):
+                    field_class = fields.Object
+                    args = (fields.String,)
+                elif postgres_ext and \
+                        isinstance(column, (postgres_ext.JSONField,
+                                            postgres_ext.BinaryJSONField)):
+                    field_class = fields.Raw
+                    kwargs = {"schema": {}}
+                else:
+                    raise RuntimeError(
+                        'No appropriate field class for "{}" found'.format(
+                            column))
+
+                kwargs['nullable'] = column.null
+
+                if column.default is not None:
+                    kwargs['default'] = column.default
+
+                io = "rw"
+                if name in read_only_fields:
+                    io = "r"
+                elif name in write_only_fields:
+                    io = "w"
+
+                if not (column.null or column.default):
+                    fs.required.add(name)
+
+                fs.set(
+                    name, field_class(*args, io=io, attribute=name, **kwargs))
+
+    def _query(self):
+        return self.model.select()
+
+    def _where_expression(self, where):
+        expressions = []
+
+        for condition in where:
+            column = getattr(self.model, condition.attribute)
+            expressions.append(
+                PW_COMPARATOR_EXPRESSIONS[condition.comparator.name](
+                    column, condition.value))
+
+        if len(expressions) == 1:
+            return expressions[0]
+
+        # TODO ranking by default with text-search.
+
+        return and_(*expressions)
+
+    def _order_by(self, sort):
+        for attribute, reverse in sort:
+            column = getattr(self.model, attribute)
+
+            if reverse:
+                yield column.desc()
+            else:
+                yield column.asc()
+
+    def relation_instances(self, item, attribute, target_resource, page=None,
+                           per_page=None):
+        query = getattr(item, attribute)
+        if page and per_page:
+            return query.paginate(page, per_page)
+        return query
+
+    def relation_add(self, item, attribute, target_resource, target_item):
+        signals.before_add_to_relation.send(
+            self.resource, item=item, attribute=attribute, child=target_item)
+
+        getattr(item, attribute).add(target_item)
+
+        signals.after_add_to_relation.send(
+            self.resource, item=item, attribute=attribute, child=target_item)
+
+    def relation_remove(self, item, attribute, target_resource, target_item):
+        signals.before_remove_from_relation.send(
+            self.resource, item=item, attribute=attribute, child=target_item)
+
+        getattr(item, attribute).remove(target_item)
+
+        signals.after_remove_from_relation.send(
+            self.resource, item=item, attribute=attribute, child=target_item)
+
+    def paginated_instances(self, page, per_page, where=None, sort=None):
+        return self.instances(where, sort).paginate(page, per_page)
+
+    def instances(self, where=None, sort=None):
+        query = self._query()
+
+        if where:
+            query = query.where(self._where_expression(where))
+        if sort:
+            query = query.order_by(*self._order_by(sort))
+
+        return query
+
+    def first(self, where=None, sort=None):
+        try:
+            return self.instances(where, sort).first()
+        except self.model.DoesNotExist:
+            raise ItemNotFound(self.resource, where=where)
+
+    def create(self, properties, commit=True):
+        item = self.model()
+
+        for key, value in properties.items():
+            setattr(item, key, value)
+
+        signals.before_create.send(
+            self.resource, item=item)
+
+        try:
+            item.save()
+        except pw.IntegrityError as e:
+            if 'UNIQUE constraint failed' in e.message:
+                raise DuplicateKey(detail=e.message)
+            raise BackendConflict()
+
+        signals.after_create.send(
+            self.resource, item=item)
+        return item
+
+    def read(self, id):
+        try:
+            return self.model.get(self.id_column == id)
+        except self.model.DoesNotExist:
+            raise ItemNotFound(self.resource, id=id)
+
+    def update(self, item, changes, commit=True):
+        actual_changes = {
+            key: value for key, value in changes.items()
+            if get_value(key, item, None) != value
+        }
+
+        signals.before_update.send(
+            self.resource, item=item, changes=actual_changes)
+
+        for key, value in changes.items():
+            setattr(item, key, value)
+
+        try:
+            item.save()
+        except pw.IntegrityError as e:
+            if 'UNIQUE constraint failed' in e.message:
+                raise DuplicateKey(detail=e.message)
+            raise
+
+        signals.after_update.send(
+            self.resource, item=item, changes=actual_changes)
+        return item
+
+    def delete(self, item):
+        signals.before_delete.send(
+            self.resource, item=item)
+
+        item.delete_instance()
+
+        signals.after_delete.send(
+            self.resource, item=item)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'jsonschema>=2.4.0',
         'aniso8601>=0.84',
         'blinker>=1.3',
+        'peewee>=2.6.3',
         'six>=1.8.0'
     ],
     classifiers=[

--- a/tests/test_manager_peewee.py
+++ b/tests/test_manager_peewee.py
@@ -1,0 +1,449 @@
+import unittest
+
+from flask_potion import Api, fields
+from flask_potion.backends.peewee import PeeweeManager
+from flask_potion.resource import ModelResource
+from flask_potion.routes import Relation
+import peewee as pw
+from playhouse.fields import ManyToManyField
+from playhouse.flask_utils import FlaskDB
+
+from tests import BaseTestCase
+
+
+class DB(FlaskDB):
+    def connect_db(self):
+        pass
+
+    def close_db(self, exc):
+        pass
+
+
+class PeeweeTestCase(BaseTestCase):
+    def setUp(self):
+        super(PeeweeTestCase, self).setUp()
+        self.app.config['DATABASE'] = 'sqlite://'
+        self.db = db = DB(self.app)
+        self.api = Api(self.app)
+
+        class Type(db.Model):
+            name = pw.CharField(max_length=60, null=False, unique=True)
+
+        class Machine(db.Model):
+            name = pw.CharField(max_length=60, null=False)
+            wattage = pw.FloatField(null=True)
+            type = pw.ForeignKeyField(Type, related_name='machines')
+        self.db.database.connect()
+        self.db.database.create_tables([Type, Machine])
+
+        class MachineResource(ModelResource):
+            class Meta:
+                model = Machine
+                include_id = True
+                include_type = True
+                manager = PeeweeManager
+
+            class Schema:
+                type = fields.ToOne('type')
+
+        class TypeResource(ModelResource):
+            class Meta:
+                model = Type
+                include_id = True
+                include_type = True
+                manager = PeeweeManager
+
+            class Schema:
+                machines = fields.ToMany(MachineResource)
+
+        self.MachineResource = MachineResource
+        self.TypeResource = TypeResource
+
+        self.api.add_resource(MachineResource)
+        self.api.add_resource(TypeResource)
+
+    def tearDown(self):
+        self.db.database.close()
+
+    def test_field_discovery(self):
+        self.assertEqual(
+            set(self.MachineResource.schema.fields.keys()),
+            {'$id', '$type', 'name', 'type', 'wattage'})
+        self.assertEqual(
+            set(self.TypeResource.schema.fields.keys()),
+            {'$id', '$type', 'name', 'machines'})
+        self.assertEqual(self.MachineResource.meta.name, 'machine')
+        self.assertEqual(self.TypeResource.meta.name, 'type')
+
+    def test_create_no_json(self):
+        response = self.client.post('/machine', data='invalid')
+        self.assert400(response)
+
+    def test_create_json_string(self):
+        response = self.client.post(
+            '/machine', data='invalid', force_json=True)
+        self.assert400(response)
+
+    def test_conflict(self):
+        response = self.client.post('/type', data={"name": "foo"})
+        self.assert200(response)
+
+        response = self.client.post('/type', data={"name": "foo"})
+        self.assertStatus(response, 409)
+
+    def test_create(self):
+        response = self.client.post('/type', data={})
+        self.assert400(response)
+        self.assertEqual({
+            "errors": [
+                {
+                    "message": "'name' is a required property",
+                    "path": [],
+                    "validationOf": {
+                        "required": [
+                            "name"
+                        ]
+                    }
+                }
+            ],
+            "message": "Bad Request",
+            "status": 400
+        }, response.json)
+
+        response = self.client.post('/type', data={"name": "x-ray"})
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'type',
+            'machines': [],
+            'name': 'x-ray'},
+            response.json)
+
+        response = self.client.post(
+            '/machine', data={"name": "Irradiator I", "type": 1})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'machine',
+            'type': {'$ref': '/type/1'},
+            'wattage': None,
+            'name': 'Irradiator I'},
+            response.json)
+
+        response = self.client.post(
+            '/machine', data={"name": "Sol IV", "type": 1, "wattage": 1.23e45})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 2,
+            '$type': 'machine',
+            'type': {'$ref': '/type/1'},
+            'wattage': 1.23e45,
+            'name': 'Sol IV'},
+            response.json)
+
+        response = self.client.get('/type/1')
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'type',
+            'machines': [
+                {'$ref': '/machine/1'},
+                {'$ref': '/machine/2'}],
+            'name': 'x-ray'},
+            response.json)
+
+    def test_get(self):
+        def type_(i):
+            return {
+                '$id': i,
+                '$type': 'type',
+                'name': 'Type-{}'.format(i),
+                'machines': []}
+
+        for i in range(1, 10):
+            with self.app.test_client() as client:
+                response = client.post(
+                    '/type',
+                    data={"name": "Type-{}".format(i), "machines": []})
+            self.pp(response.json)
+            self.assert200(response)
+            self.assertJSONEqual(type_(i), response.json)
+
+            with self.app.test_client() as client:
+                response = client.get('/type/{}'.format(i))
+            self.assert200(response)
+            self.assertJSONEqual(type_(i), response.json)
+
+            with self.app.test_client() as client:
+                response = client.get('/type')
+            self.assert200(response)
+            self.assertJSONEqual(
+                [type_(i) for i in range(1, i + 1)],
+                response.json)
+
+            with self.app.test_client() as client:
+                response = client.get('/type/{}'.format(i + 1))
+            self.assert404(response)
+            self.assertJSONEqual({
+                'item': {'$id': i + 1, '$type': 'type'},
+                'message': 'Not Found',
+                'status': 404},
+                response.json)
+
+    @unittest.SkipTest
+    def test_pagination(self):
+        pass # TODO
+
+    def test_update(self):
+        response = self.client.post('/type', data={"name": "T1"})
+        self.assert200(response)
+
+        response = self.client.post('/type', data={"name": "T2"})
+        self.assert200(response)
+
+        response = self.client.post(
+            '/machine', data={'name': 'Robot', 'type': 1})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'machine',
+            'type': {'$ref': '/type/1'},
+            'wattage': None,
+            'name': 'Robot'},
+            response.json)
+
+        response = self.client.patch('/machine/1', data={})
+        self.assert200(response)
+
+        response = self.client.patch('/machine/1', data={"wattage": 10000})
+        self.pp(response.json)
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'machine',
+            'type': {'$ref': '/type/1'},
+            'wattage': 10000,
+            'name': 'Robot'},
+            response.json)
+
+        response = self.client.patch(
+            '/machine/1', data={"type": {"$ref": "/type/2"}})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'machine',
+            'type': {'$ref': '/type/2'},
+            'wattage': 10000,
+            'name': 'Robot'},
+            response.json)
+
+        response = self.client.patch('/machine/1', data={"type": None})
+        self.assert400(response)
+        self.pp(response.json)
+        self.assertJSONEqual({
+            "errors": [{
+                "message": "None is not valid under any of the given schemas",
+                "path": [
+                    "type"],
+                "validationOf": {
+                    "anyOf": [{
+                        "additionalProperties": False,
+                        "properties": {
+                            "$ref": {
+                                "format": "uri",
+                                "pattern": "^\\/type\\/[^/]+$",
+                                "type": "string"}},
+                            "type": "object"}, {
+                                "type": "integer"}]}}],
+            'message': 'Bad Request',
+            'status': 400},
+            response.json)
+
+        response = self.client.patch('/machine/1', data={"name": "Foo"})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'machine',
+            'type': {'$ref': '/type/2'},
+            'wattage': 10000,
+            'name': 'Foo'},
+            response.json)
+
+    def test_delete(self):
+        response = self.client.delete('/type/1')
+        self.assert404(response)
+
+        response = self.client.post(
+            '/type', data={"name": "Foo", "machines": []})
+        self.assert200(response)
+
+        response = self.client.delete('/type/1')
+        self.assertStatus(response, 204)
+
+        response = self.client.delete('/type/1')
+        self.assert404(response)
+
+
+class PeeweeRelationTestCase(BaseTestCase):
+    def setUp(self):
+        super(PeeweeRelationTestCase, self).setUp()
+
+        self.app.config['DATABASE'] = 'sqlite://'
+        self.db = db = DB(self.app)
+        self.api = Api(self.app)
+
+        class User(db.Model):
+            parent = pw.ForeignKeyField('self', related_name='children',
+                                        null=True)
+            name = pw.CharField(max_length=60, null=False)
+
+        class Group(db.Model):
+            name = pw.CharField(max_length=60, null=False)
+            members = ManyToManyField(User, related_name='memberships')
+
+        db.database.connect()
+        db.database.create_tables([
+            User,
+            Group,
+            Group.members.get_through_model()])
+
+        self.User = User
+        self.Group = Group
+
+        class UserResource(ModelResource):
+            class Meta:
+                model = User
+                include_id = True
+                include_type = True
+                manager = PeeweeManager
+
+            children = Relation('self')
+
+        class GroupResource(ModelResource):
+            class Meta:
+                model = Group
+                include_id = True
+                include_type = True
+                manager = PeeweeManager
+
+            members = Relation('user')
+
+        self.api.add_resource(UserResource)
+        self.api.add_resource(GroupResource)
+
+    def tearDown(self):
+        self.db.database.drop_tables([
+            self.Group.members.get_through_model(),
+            self.Group,
+            self.User])
+
+        if not self.db.database.is_closed():
+            self.db.database.close()
+
+    def test_relationship_secondary(self):
+        response = self.client.post('/group', data={"name": "Foo"})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'group',
+            'name': 'Foo'},
+            response.json)
+
+        response = self.client.post('/user', data={'name': 'Bar'})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'user',
+            'name': 'Bar'},
+            response.json)
+
+        response = self.client.get('/group/1/members')
+        self.assert200(response)
+        self.assertJSONEqual([], response.json)
+
+        response = self.client.post(
+            '/group/1/members', data={"$ref": "/user/1"})
+        self.assert200(response)
+        self.assertJSONEqual({"$ref": "/user/1"}, response.json)
+
+        response = self.client.get('/group/1/members')
+        self.assert200(response)
+        self.assertJSONEqual([{"$ref": "/user/1"}], response.json)
+
+    def test_relationship_post(self):
+        with self.app.test_client() as client:
+            response = client.post('/user', data={"name": "Foo"})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 1,
+            '$type': 'user',
+            'name': 'Foo'},
+            response.json)
+
+        with self.app.test_client() as client:
+            response = client.post('/user', data={"name": "Bar"})
+        self.assert200(response)
+        self.assertJSONEqual({
+            '$id': 2,
+            '$type': 'user',
+            'name': 'Bar'},
+            response.json)
+
+        with self.app.test_client() as client:
+            response = client.post(
+                '/user/1/children', data={'$ref': '/user/2'})
+        self.assert200(response)
+        self.assertJSONEqual({"$ref": "/user/2"}, response.json)
+
+    def test_relationship_get(self):
+        self.test_relationship_post()
+
+        response = self.client.get('/user/1/children')
+        self.assert200(response)
+        self.assertJSONEqual([{"$ref": "/user/2"}], response.json)
+
+    def test_relationship_delete(self):
+        self.test_relationship_post()
+
+        response = self.client.delete('/user/1/children/2')
+        self.assertStatus(response, 204)
+
+        response = self.client.get('/user/1/children')
+        self.assert200(response)
+        self.assertJSONEqual([], response.json)
+
+    def test_relationship_pagination(self):
+        with self.app.test_client() as client:
+            response = self.client.post('/user', data={"name": "Foo"})
+        self.assert200(response)
+
+        for i in range(2, 50):
+            with self.app.test_client() as client:
+                response = client.post('/user', data={"name": str(i)})
+            self.assert200(response)
+            with self.app.test_client() as client:
+                response = client.post(
+                    '/user/1/children',
+                    data={"$ref": "/user/{}".format(response.json['$id'])})
+            self.assert200(response)
+
+        with self.app.test_client() as client:
+            response = client.get('/user/1/children')
+        self.assert200(response)
+        self.assertJSONEqual(
+            [{"$ref": "/user/{}".format(i)} for i in range(2, 22)],
+            response.json)
+
+        with self.app.test_client() as client:
+            response = client.get('/user/1/children?page=3')
+        self.assert200(response)
+        self.assertJSONEqual(
+            [{'$ref': '/user/{}'.format(i)} for i in range(42, 50)],
+            response.json)
+
+        self.assertEqual('48', response.headers['X-Total-Count'])
+        self.assertEqual(
+            '</user/1/children?page=3&per_page=20>; rel="self",'
+            '</user/1/children?page=1&per_page=20>; rel="first",'
+            '</user/1/children?page=2&per_page=20>; rel="prev",'
+            '</user/1/children?page=3&per_page=20>; rel="last"',
+            response.headers['Link'])

--- a/tests/test_manager_peewee.py
+++ b/tests/test_manager_peewee.py
@@ -85,32 +85,32 @@ class PeeweeTestCase(BaseTestCase):
         self.assert400(response)
 
     def test_conflict(self):
-        response = self.client.post('/type', data={"name": "foo"})
+        response = self.client.post('/type', data={'name': 'foo'})
         self.assert200(response)
 
-        response = self.client.post('/type', data={"name": "foo"})
+        response = self.client.post('/type', data={'name': 'foo'})
         self.assertStatus(response, 409)
 
     def test_create(self):
         response = self.client.post('/type', data={})
         self.assert400(response)
         self.assertEqual({
-            "errors": [
+            'errors': [
                 {
-                    "message": "'name' is a required property",
-                    "path": [],
-                    "validationOf": {
-                        "required": [
-                            "name"
+                    'message': "'name' is a required property",
+                    'path': [],
+                    'validationOf': {
+                        'required': [
+                            'name'
                         ]
                     }
                 }
             ],
-            "message": "Bad Request",
-            "status": 400
+            'message': 'Bad Request',
+            'status': 400
         }, response.json)
 
-        response = self.client.post('/type', data={"name": "x-ray"})
+        response = self.client.post('/type', data={'name': 'x-ray'})
         self.assertJSONEqual({
             '$id': 1,
             '$type': 'type',
@@ -119,7 +119,7 @@ class PeeweeTestCase(BaseTestCase):
             response.json)
 
         response = self.client.post(
-            '/machine', data={"name": "Irradiator I", "type": 1})
+            '/machine', data={'name': 'Irradiator I', 'type': 1})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 1,
@@ -130,7 +130,7 @@ class PeeweeTestCase(BaseTestCase):
             response.json)
 
         response = self.client.post(
-            '/machine', data={"name": "Sol IV", "type": 1, "wattage": 1.23e45})
+            '/machine', data={'name': 'Sol IV', 'type': 1, 'wattage': 1.23e45})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 2,
@@ -160,28 +160,24 @@ class PeeweeTestCase(BaseTestCase):
                 'machines': []}
 
         for i in range(1, 10):
-            with self.app.test_client() as client:
-                response = client.post(
-                    '/type',
-                    data={"name": "Type-{}".format(i), "machines": []})
+            response = self.client.post(
+                '/type',
+                data={'name': 'Type-{}'.format(i), 'machines': []})
             self.pp(response.json)
             self.assert200(response)
             self.assertJSONEqual(type_(i), response.json)
 
-            with self.app.test_client() as client:
-                response = client.get('/type/{}'.format(i))
+            response = self.client.get('/type/{}'.format(i))
             self.assert200(response)
             self.assertJSONEqual(type_(i), response.json)
 
-            with self.app.test_client() as client:
-                response = client.get('/type')
+            response = self.client.get('/type')
             self.assert200(response)
             self.assertJSONEqual(
                 [type_(i) for i in range(1, i + 1)],
                 response.json)
 
-            with self.app.test_client() as client:
-                response = client.get('/type/{}'.format(i + 1))
+            response = self.client.get('/type/{}'.format(i + 1))
             self.assert404(response)
             self.assertJSONEqual({
                 'item': {'$id': i + 1, '$type': 'type'},
@@ -194,10 +190,10 @@ class PeeweeTestCase(BaseTestCase):
         pass # TODO
 
     def test_update(self):
-        response = self.client.post('/type', data={"name": "T1"})
+        response = self.client.post('/type', data={'name': 'T1'})
         self.assert200(response)
 
-        response = self.client.post('/type', data={"name": "T2"})
+        response = self.client.post('/type', data={'name': 'T2'})
         self.assert200(response)
 
         response = self.client.post(
@@ -214,7 +210,7 @@ class PeeweeTestCase(BaseTestCase):
         response = self.client.patch('/machine/1', data={})
         self.assert200(response)
 
-        response = self.client.patch('/machine/1', data={"wattage": 10000})
+        response = self.client.patch('/machine/1', data={'wattage': 10000})
         self.pp(response.json)
         self.assert200(response)
         self.assertJSONEqual({
@@ -226,7 +222,7 @@ class PeeweeTestCase(BaseTestCase):
             response.json)
 
         response = self.client.patch(
-            '/machine/1', data={"type": {"$ref": "/type/2"}})
+            '/machine/1', data={'type': {'$ref': '/type/2'}})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 1,
@@ -236,29 +232,29 @@ class PeeweeTestCase(BaseTestCase):
             'name': 'Robot'},
             response.json)
 
-        response = self.client.patch('/machine/1', data={"type": None})
+        response = self.client.patch('/machine/1', data={'type': None})
         self.assert400(response)
         self.pp(response.json)
         self.assertJSONEqual({
-            "errors": [{
-                "message": "None is not valid under any of the given schemas",
-                "path": [
-                    "type"],
-                "validationOf": {
-                    "anyOf": [{
-                        "additionalProperties": False,
-                        "properties": {
-                            "$ref": {
-                                "format": "uri",
-                                "pattern": "^\\/type\\/[^/]+$",
-                                "type": "string"}},
-                            "type": "object"}, {
-                                "type": "integer"}]}}],
+            'errors': [{
+                'message': 'None is not valid under any of the given schemas',
+                'path': [
+                    'type'],
+                'validationOf': {
+                    'anyOf': [{
+                        'additionalProperties': False,
+                        'properties': {
+                            '$ref': {
+                                'format': 'uri',
+                                'pattern': '^\\/type\\/[^/]+$',
+                                'type': 'string'}},
+                            'type': 'object'}, {
+                                'type': 'integer'}]}}],
             'message': 'Bad Request',
             'status': 400},
             response.json)
 
-        response = self.client.patch('/machine/1', data={"name": "Foo"})
+        response = self.client.patch('/machine/1', data={'name': 'Foo'})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 1,
@@ -273,7 +269,7 @@ class PeeweeTestCase(BaseTestCase):
         self.assert404(response)
 
         response = self.client.post(
-            '/type', data={"name": "Foo", "machines": []})
+            '/type', data={'name': 'Foo', 'machines': []})
         self.assert200(response)
 
         response = self.client.delete('/type/1')
@@ -340,7 +336,7 @@ class PeeweeRelationTestCase(BaseTestCase):
             self.db.database.close()
 
     def test_relationship_secondary(self):
-        response = self.client.post('/group', data={"name": "Foo"})
+        response = self.client.post('/group', data={'name': 'Foo'})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 1,
@@ -361,17 +357,16 @@ class PeeweeRelationTestCase(BaseTestCase):
         self.assertJSONEqual([], response.json)
 
         response = self.client.post(
-            '/group/1/members', data={"$ref": "/user/1"})
+            '/group/1/members', data={'$ref': '/user/1'})
         self.assert200(response)
-        self.assertJSONEqual({"$ref": "/user/1"}, response.json)
+        self.assertJSONEqual({'$ref': '/user/1'}, response.json)
 
         response = self.client.get('/group/1/members')
         self.assert200(response)
-        self.assertJSONEqual([{"$ref": "/user/1"}], response.json)
+        self.assertJSONEqual([{'$ref': '/user/1'}], response.json)
 
     def test_relationship_post(self):
-        with self.app.test_client() as client:
-            response = client.post('/user', data={"name": "Foo"})
+        response = self.client.post('/user', data={'name': 'Foo'})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 1,
@@ -379,8 +374,7 @@ class PeeweeRelationTestCase(BaseTestCase):
             'name': 'Foo'},
             response.json)
 
-        with self.app.test_client() as client:
-            response = client.post('/user', data={"name": "Bar"})
+        response = self.client.post('/user', data={'name': 'Bar'})
         self.assert200(response)
         self.assertJSONEqual({
             '$id': 2,
@@ -388,18 +382,17 @@ class PeeweeRelationTestCase(BaseTestCase):
             'name': 'Bar'},
             response.json)
 
-        with self.app.test_client() as client:
-            response = client.post(
-                '/user/1/children', data={'$ref': '/user/2'})
+        response = self.client.post(
+            '/user/1/children', data={'$ref': '/user/2'})
         self.assert200(response)
-        self.assertJSONEqual({"$ref": "/user/2"}, response.json)
+        self.assertJSONEqual({'$ref': '/user/2'}, response.json)
 
     def test_relationship_get(self):
         self.test_relationship_post()
 
         response = self.client.get('/user/1/children')
         self.assert200(response)
-        self.assertJSONEqual([{"$ref": "/user/2"}], response.json)
+        self.assertJSONEqual([{'$ref': '/user/2'}], response.json)
 
     def test_relationship_delete(self):
         self.test_relationship_post()
@@ -412,29 +405,24 @@ class PeeweeRelationTestCase(BaseTestCase):
         self.assertJSONEqual([], response.json)
 
     def test_relationship_pagination(self):
-        with self.app.test_client() as client:
-            response = self.client.post('/user', data={'name': 'Foo'})
+        response = self.client.post('/user', data={'name': 'Foo'})
         self.assert200(response)
 
         for i in range(2, 50):
-            with self.app.test_client() as client:
-                response = client.post('/user', data={'name': str(i)})
+            response = self.client.post('/user', data={'name': str(i)})
             self.assert200(response)
-            with self.app.test_client() as client:
-                response = client.post(
-                    '/user/1/children',
-                    data={'$ref': '/user/{}'.format(response.json['$id'])})
+            response = self.client.post(
+                '/user/1/children',
+                data={'$ref': '/user/{}'.format(response.json['$id'])})
             self.assert200(response)
 
-        with self.app.test_client() as client:
-            response = client.get('/user/1/children')
+        response = self.client.get('/user/1/children')
         self.assert200(response)
         self.assertJSONEqual(
-            [{"$ref": "/user/{}".format(i)} for i in range(2, 22)],
+            [{'$ref': '/user/{}'.format(i)} for i in range(2, 22)],
             response.json)
 
-        with self.app.test_client() as client:
-            response = client.get('/user/1/children?page=3')
+        response = self.client.get('/user/1/children?page=3')
         self.assert200(response)
         self.assertJSONEqual(
             [{'$ref': '/user/{}'.format(i)} for i in range(42, 50)],

--- a/tests/test_manager_peewee.py
+++ b/tests/test_manager_peewee.py
@@ -413,17 +413,17 @@ class PeeweeRelationTestCase(BaseTestCase):
 
     def test_relationship_pagination(self):
         with self.app.test_client() as client:
-            response = self.client.post('/user', data={"name": "Foo"})
+            response = self.client.post('/user', data={'name': 'Foo'})
         self.assert200(response)
 
         for i in range(2, 50):
             with self.app.test_client() as client:
-                response = client.post('/user', data={"name": str(i)})
+                response = client.post('/user', data={'name': str(i)})
             self.assert200(response)
             with self.app.test_client() as client:
                 response = client.post(
                     '/user/1/children',
-                    data={"$ref": "/user/{}".format(response.json['$id'])})
+                    data={'$ref': '/user/{}'.format(response.json['$id'])})
             self.assert200(response)
 
         with self.app.test_client() as client:
@@ -439,11 +439,3 @@ class PeeweeRelationTestCase(BaseTestCase):
         self.assertJSONEqual(
             [{'$ref': '/user/{}'.format(i)} for i in range(42, 50)],
             response.json)
-
-        self.assertEqual('48', response.headers['X-Total-Count'])
-        self.assertEqual(
-            '</user/1/children?page=3&per_page=20>; rel="self",'
-            '</user/1/children?page=1&per_page=20>; rel="first",'
-            '</user/1/children?page=2&per_page=20>; rel="prev",'
-            '</user/1/children?page=3&per_page=20>; rel="last"',
-            response.headers['Link'])


### PR DESCRIPTION
Trying my hand at a peewee backend for potion. The only part I haven't figured out is the relation_add and relation_remove methods. Peewee supports many-to-many relations using a playhouse extension, which is currently implemented. But for one-to-many, for example, the relation_* methods appear to be implemented in a reverse manner to what peewee expects. For example:

    class User(Model):
        parent = ForeignKeyField('self', null=True, related_name='children')
        name = CharField()

You can't do:

    parent = User.create(name='foo')
    child = User.create(name='bar')
    parent.children.add(child)

Instead you would do:

    child.parent = parent

But relation_add/relation_remove only provide the item attribute and not the target attribute. So I'd have to figure out a way to get that attribute via peewee in some way. Haven't found a way to do this yet.