### PR TITLE
Improving compatibility: more query and more fields

### DIFF
--- a/flask_potion/backends/mongoengine.py
+++ b/flask_potion/backends/mongoengine.py
@@ -68,19 +68,12 @@ COMPARATOR_EXPRESSIONS = {
 
 
 MONGO_FIELDS_MAPPING = {
-    mongo_fields.CachedReferenceField: fields.Object,
-    mongo_fields.ReferenceField: fields.Object,
     mongo_fields.ObjectIdField: custom_fields.ObjectId,
     mongo_fields.IntField: fields.Integer,
     mongo_fields.FloatField: fields.Number,
     mongo_fields.BooleanField: fields.Boolean,
-    mongo_fields.ListField: fields.List,
-    mongo_fields.SortedListField: fields.List,
-    mongo_fields.EmbeddedDocumentListField: fields.List,
     mongo_fields.LongField: fields.Number,
     mongo_fields.BinaryField: fields.List,
-    # TODO: map key constraints properly (DictField and MapField have different enforced constraints on key)
-    mongo_fields.MapField: fields.Object,
     mongo_fields.DateTimeField: fields.Date,
     mongo_fields.ComplexDateTimeField: fields.DateTime
 }
@@ -164,8 +157,11 @@ class MongoEngineManager(Manager):
             args = (model, properties, )
         elif isinstance(field, mongo_fields.DictField):
             field_class = fields.Object
-            properties = self._get_field_from_mongoengine_type(field.field)
-            args = (properties, )
+            if field.field is not None:
+                properties = self._get_field_from_mongoengine_type(field.field)
+                args = (properties, )
+            else:
+                args = (fields.Any, )
         elif isinstance(field, mongo_fields.UUIDField):  # TODO support UUIDfield
             field_class = fields.String
             kwargs['max_length'] = 36

--- a/flask_potion/backends/mongoengine.py
+++ b/flask_potion/backends/mongoengine.py
@@ -25,7 +25,6 @@ class custom_fields:
             else:
                 return value
 
-
 MONGO_REFERENCE_FIELD_TYPES = (
     mongo_fields.ReferenceField,
     mongo_fields.CachedReferenceField,
@@ -44,20 +43,26 @@ COMPARATOR_EXPRESSIONS = {
     '$contains': lambda column, value: {"%s__contains" % column: value},
     '$startswith': lambda column, value: {"%s__startswith" % column: value.replace('%', '\\%')},
     '$endswith': lambda column, value: {"%s__endswith" % column: value.replace('%', '\\%')},
-    # TODO: $istartswith and $iendswith filters
+    '$istartswith': lambda column, value: {"%s__istartswith" % column: value.replace('%', '\\%')},
+    '$iendswith': lambda column, value: {"%s__iendswith" % column: value.replace('%', '\\%')},
 }
 
 MONGO_FIELDS_MAPPING = {
+    mongo_fields.EmbeddedDocumentField: fields.Object,
+    mongo_fields.CachedReferenceField: fields.Object,
     mongo_fields.ReferenceField: fields.Object,
     mongo_fields.ObjectIdField: custom_fields.ObjectId,
     mongo_fields.IntField: fields.Integer,
     mongo_fields.FloatField: fields.Number,
     mongo_fields.BooleanField: fields.Boolean,
-    mongo_fields.ListField: fields.Array,
-    mongo_fields.SortedListField: fields.Array,
+    mongo_fields.ListField: fields.List,
+    mongo_fields.SortedListField: fields.List,
+    mongo_fields.EmbeddedDocumentListField: fields.List,
     mongo_fields.LongField: fields.Number,
-    mongo_fields.BinaryField: fields.Array,
+    mongo_fields.BinaryField: fields.List,
+    # TODO: map key constraints properly (DictField and MapField have different enforced constraints on key)
     mongo_fields.DictField: fields.Object,
+    mongo_fields.MapField: fields.Object,
     mongo_fields.DateTimeField: fields.Date,
     mongo_fields.ComplexDateTimeField: fields.DateTime
 }
@@ -82,7 +87,7 @@ class MongoEngineManager(Manager):
         if resource.meta.include_id:
             resource.schema.set("$id", custom_fields.ObjectId(io='r', attribute=self.id_attribute))
 
-        # resource name: use model table's name if not set explicitly
+        # resource name: use model collection's name if not set explicitly
         if not hasattr(resource.Meta, 'name'):
             meta['name'] = model._meta.get('collection', model.__class__.__name__).lower()
 
@@ -133,20 +138,19 @@ class MongoEngineManager(Manager):
         if isinstance(property, mongo_fields.ListField):
             field_class = fields.Array
             args = (self._get_field_from_mongoengine_type(property.field)[0],)
+        elif isinstance(property, mongo_fields.EmbeddedDocumentField):
+            field_class = fields.Inline
+            args = (property.document_type_obj, )
         elif isinstance(property, mongo_fields.UUIDField):  # TODO support UUIDfield
             field_class = fields.String
-            kwargs = {
-                'max_length': 36,
-                'min_length': 36,
-            }
+            kwargs['max_length'] = 36
+            kwargs['min_length'] = 36
         elif isinstance(property, mongo_fields.StringField):
             field_class = fields.String
-            kwargs = {
-                'max_length': property.max_length,
-                'min_length': property.min_length,
-                'enum': property.choices,
-                'pattern': property.regex
-            }
+            kwargs['max_length'] = property.max_length
+            kwargs['min_length'] = property.min_length
+            kwargs['enum'] = property.choices
+            kwargs['pattern'] = property.regex
         else:
             try:
                 field_class = MONGO_FIELDS_MAPPING[type(property)]
@@ -155,6 +159,7 @@ class MongoEngineManager(Manager):
 
         kwargs['nullable'] = property.null
         kwargs['default'] = property.default
+        kwargs['description'] = property.help_text
         return field_class, args, kwargs
 
     def _where_expression(self, where):

--- a/flask_potion/backends/mongoengine.py
+++ b/flask_potion/backends/mongoengine.py
@@ -219,8 +219,7 @@ class MongoEngineManager(Manager):
         after_remove_from_relation.send(self.resource, item=item, attribute=attribute, child=target_item)
 
     def paginated_instances(self, page, per_page, where=None, sort=None):
-        instances = self.instances(where=where, sort=sort)
-        return Pagination(instances, page, per_page, instances.count())
+        return self.instances(where=where, sort=sort).paginate(page=page, per_page=per_page)
 
     def instances(self, where=None, sort=None):
         query = self.model.objects

--- a/flask_potion/backends/mongoengine.py
+++ b/flask_potion/backends/mongoengine.py
@@ -43,6 +43,7 @@ COMPARATOR_EXPRESSIONS = {
     '$contains': lambda column, value: {"%s__contains" % column: value},
     '$startswith': lambda column, value: {"%s__startswith" % column: value.replace('%', '\\%')},
     '$endswith': lambda column, value: {"%s__endswith" % column: value.replace('%', '\\%')},
+    '%icontains': lambda column, value: {"%s__icontains" % column: value.replace('%', '\\%')},
     '$istartswith': lambda column, value: {"%s__istartswith" % column: value.replace('%', '\\%')},
     '$iendswith': lambda column, value: {"%s__iendswith" % column: value.replace('%', '\\%')},
 }

--- a/flask_potion/backends/mongoengine.py
+++ b/flask_potion/backends/mongoengine.py
@@ -33,11 +33,8 @@ class custom_fields:
             super(custom_fields.EmbeddedField, self).__init__(*args, **kwargs)
             self.model = model
 
-        def formatter(self, value):
-            if value is not None:
-                return value.to_mongo()
-
         def converter(self, value):
+            value = super(custom_fields.EmbeddedField, self).converter(value)
             if value is not None:
                 return self.model(**value)
 

--- a/flask_potion/backends/mongoengine.py
+++ b/flask_potion/backends/mongoengine.py
@@ -197,7 +197,7 @@ class MongoEngineManager(Manager):
             if reverse:
                 yield "-%s" % attribute
             else:
-                yield "%s" % attribute
+                yield "+%s" % attribute
 
     def relation_instances(self, item, attribute, target_resource, page=None, per_page=None):
         query = getattr(item, attribute)

--- a/flask_potion/instances.py
+++ b/flask_potion/instances.py
@@ -12,11 +12,21 @@ from .reference import ResourceBound
 from .utils import get_value
 from .schema import Schema
 
+available_paginations = [Pagination]
+
 try:
     from flask_sqlalchemy import Pagination as SAPagination
-    PAGINATION_TYPES = (Pagination, SAPagination)
+    available_paginations.append(SAPagination)
 except ImportError:
-    PAGINATION_TYPES = (Pagination,)
+    pass
+
+try:
+    from flask_mongoengine import Pagination as MEPagination
+    available_paginations.append(MEPagination)
+except ImportError:
+    pass
+
+PAGINATION_TYPES = tuple(available_paginations)
 
 
 Comparator = namedtuple('Comparator', ['name', 'schema', 'expression', 'supported_types'])

--- a/tests/backends/mongoengine/test_fields.py
+++ b/tests/backends/mongoengine/test_fields.py
@@ -80,7 +80,20 @@ class FieldsTestCase(BaseTestCase):
                          })
         self.assertEqual(response.json['properties']['reference_mapping']['default'], {})
         ref_model = dict(id='adfb48a6763c5741b92f6ade')
-        self.client.post("/model", data={'reference_mapping': {"1": ref_model}, 'object_id_mapping': ref_model["id"]})
+        response = self.client.post("/model", data={'reference_mapping': {"1": ref_model}, 'object_id_mapping': {"a": ref_model["id"]}})
+        self.assertJSONEqual(response.json,
+                             {
+                                 'reference_mapping': {
+                                     '1': {
+                                         'id': 'adfb48a6763c5741b92f6ade'
+                                     }
+                                 },
+                                 '$uri': '/model/561e6a807f551ce7d5df1003',
+                                 'float_mapping': {},
+                                 'object_id_mapping': {
+                                     'a': 'adfb48a6763c5741b92f6ade'
+                                 }, 'string_mapping': {}
+                             })
 
 
     def tearDown(self):

--- a/tests/backends/mongoengine/test_fields.py
+++ b/tests/backends/mongoengine/test_fields.py
@@ -1,0 +1,87 @@
+from bson import ObjectId
+from bson.errors import InvalidId
+from flask.ext.mongoengine import MongoEngine
+from mongoengine import ObjectIdField, MapField, FloatField, StringField, EmbeddedDocumentField, \
+    EmbeddedDocument
+from flask_potion import Api, ModelResource
+from flask_potion.backends.mongoengine import MongoEngineManager
+from tests import BaseTestCase
+
+
+class FieldsTestCase(BaseTestCase):
+    def setUp(self):
+        super(FieldsTestCase, self).setUp()
+        app = self.app
+        app.config['MONGODB_DB'] = 'potion-test-db'
+        app.config['TESTING'] = True
+
+        self.api = Api(self.app, default_manager=MongoEngineManager)
+        self.me = MongoEngine(app)
+
+    def test_object_id_field(self):
+        class Model(self.me.Document):
+            meta = {
+                'collection': 'model'
+            }
+
+            an_id = ObjectIdField()
+
+        class Resource(ModelResource):
+            class Meta:
+                model = Model
+
+        self.api.add_resource(Resource)
+
+        response = self.client.get('/model/schema')
+        self.assertEqual(response.json['properties']['an_id'], {'type': 'string'})
+        self.assertRaises(InvalidId, self.client.post, '/model', data={'an_id': "abc"})
+
+        hex = 'adfb48a6763c5741b92f6ade'
+        object_id = ObjectId('adfb48a6763c5741b92f6ade')
+        response = self.client.post('/model', data={'an_id': hex})
+        self.assertEqual(object_id, ObjectId(response.json['an_id']))
+
+    def test_map_field(self):
+
+        class ReferenceModel(EmbeddedDocument):
+            id = ObjectIdField()
+            meta = {
+                'collection': 'reference-model'
+            }
+
+        class Model(self.me.Document):
+            meta = {
+                'collection': 'model'
+            }
+
+            float_mapping = MapField(FloatField())
+            string_mapping = MapField(StringField())
+            object_id_mapping = MapField(ObjectIdField())
+            reference_mapping = MapField(EmbeddedDocumentField(ReferenceModel))
+
+        class Resource(ModelResource):
+            class Meta:
+                model = Model
+
+        self.api.add_resource(Resource)
+
+        response = self.client.get('/model/schema')
+        self.assertEqual(response.json['properties']['float_mapping']['additionalProperties'], {'type': 'number'})
+        self.assertEqual(response.json['properties']['float_mapping']['default'], {})
+        self.assertEqual(response.json['properties']['string_mapping']['additionalProperties'], {'type': 'string'})
+        self.assertEqual(response.json['properties']['string_mapping']['default'], {})
+        self.assertEqual(response.json['properties']['reference_mapping']['additionalProperties'],
+                         {
+                             'additionalProperties': False,
+                             'type': 'object',
+                             'properties': {
+                                 'id': {'type': 'string'}
+                             }
+                         })
+        self.assertEqual(response.json['properties']['reference_mapping']['default'], {})
+        ref_model = dict(id='adfb48a6763c5741b92f6ade')
+        self.client.post("/model", data={'reference_mapping': {"1": ref_model}, 'object_id_mapping': ref_model["id"]})
+
+
+    def tearDown(self):
+        self.me.connection.drop_database('potion-test-db')

--- a/tests/backends/mongoengine/test_fields.py
+++ b/tests/backends/mongoengine/test_fields.py
@@ -81,20 +81,20 @@ class FieldsTestCase(BaseTestCase):
         self.assertEqual(response.json['properties']['reference_mapping']['default'], {})
         ref_model = dict(id='adfb48a6763c5741b92f6ade')
         response = self.client.post("/model", data={'reference_mapping': {"1": ref_model}, 'object_id_mapping': {"a": ref_model["id"]}})
-        self.assertJSONEqual(response.json,
-                             {
-                                 'reference_mapping': {
-                                     '1': {
-                                         'id': 'adfb48a6763c5741b92f6ade'
-                                     }
-                                 },
-                                 '$uri': '/model/561e6a807f551ce7d5df1003',
-                                 'float_mapping': {},
-                                 'object_id_mapping': {
-                                     'a': 'adfb48a6763c5741b92f6ade'
-                                 }, 'string_mapping': {}
-                             })
-
+        self.assertEqualWithout(response.json,
+                                {
+                                    'reference_mapping': {
+                                        '1': {
+                                            'id': 'adfb48a6763c5741b92f6ade'
+                                        }
+                                    },
+                                    '$uri': '/model/561e6a807f551ce7d5df1003',
+                                    'float_mapping': {},
+                                    'object_id_mapping': {
+                                        'a': 'adfb48a6763c5741b92f6ade'
+                                    }, 'string_mapping': {}
+                                },
+                                without=["$uri"])
 
     def tearDown(self):
         self.me.connection.drop_database('potion-test-db')


### PR DESCRIPTION
icontains, istartswith and iendswith are supported by MongoEngine (http://docs.mongoengine.org/guide/querying.html)

Support more fields: 
EmbeddedDocumentField
CachedReferenceField
EmbeddedDocumentListField
MapField