### PR TITLE
Initial support for Blueprints

### DIFF
--- a/flask_potion/__init__.py
+++ b/flask_potion/__init__.py
@@ -155,10 +155,7 @@ class Api(object):
         return OrderedDict(schema), 200, {'Content-Type': 'application/schema+json'}
 
     def add_route(self, route, resource, endpoint=None, decorator=None):
-        if self.blueprint is None:
-            endpoint = endpoint or '.'.join((resource.meta.name, route.relation))
-        else:
-            endpoint = endpoint or '_'.join((resource.meta.name, route.relation))
+        endpoint = endpoint or '_'.join((resource.meta.name, route.relation))
         methods = [route.method]
         rule = route.rule_factory(resource)
 

--- a/flask_potion/__init__.py
+++ b/flask_potion/__init__.py
@@ -97,11 +97,19 @@ class Api(object):
         app.config.setdefault('POTION_MAX_PER_PAGE', 100)
         app.config.setdefault('POTION_DEFAULT_PER_PAGE', 20)
 
-        app.add_url_rule(
-            rule=''.join((self.prefix, '/schema')),
-            view_func=self.output(self._schema_view),
-            endpoint='schema',
-            methods=['GET'])
+        if self.blueprint:
+            self.blueprint.add_url_rule(
+                rule=''.join((self.prefix, '/schema')),
+                view_func=self.output(self._schema_view),
+                endpoint='schema',
+                methods=['GET']
+            )
+        else:
+            app.add_url_rule(
+                rule=''.join((self.prefix, '/schema')),
+                view_func=self.output(self._schema_view),
+                endpoint='schema',
+                methods=['GET'])
 
         for rule, view, endpoint, methods in self.views:
             app.add_url_rule(rule, view_func=view, endpoint=endpoint, methods=methods)
@@ -169,7 +177,9 @@ class Api(object):
         for decorator in self.decorators:
             view = decorator(view)
 
-        if self.app:
+        if self.blueprint:
+            self.blueprint.add_url_rule(rule, view_func=view, endpoint=endpoint, methods=methods)
+        elif self.app:
             self.app.add_url_rule(rule, view_func=view, endpoint=endpoint, methods=methods)
         else:
             self.views.append((rule, view, endpoint, methods))

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -1,0 +1,23 @@
+from flask import Blueprint
+from flask_potion import Api
+from flask_potion.contrib.memory.manager import MemoryManager
+from flask_potion.resource import ModelResource
+from tests import BaseTestCase
+
+
+class BlueprintApiTestCase(BaseTestCase):
+    def test_api_blueprint(self):
+        class SampleResource(ModelResource):
+            class Meta:
+                name = "samples"
+                model = "samples"
+                manager = MemoryManager
+
+        api_bp = Blueprint("potion_blueprint", __name__.split(".")[0])
+        api = Api(api_bp)
+        api.add_resource(SampleResource)
+
+        # Register Blueprint
+        self.app.register_blueprint(api_bp)
+        response = self.client.get("/samples")
+        self.assert200(response)

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -46,11 +46,11 @@ class BlueprintApiTestCase(BaseTestCase):
     def test_multiple_blueprints(self):
         # Create Blueprints
         api_bp1 = Blueprint("potion1", __name__.split(".")[0])
-        api_bp2 = Blueprint("potion2", __name__.split(".")[0])
+        api_bp2 = Blueprint("potion2", __name__.split(".")[0], url_prefix="/api")
 
         # Create Api objects, add resources, and register blueprints with app
         api1 = Api(api_bp1, prefix="/api/v1")
-        api2 = Api(api_bp2, prefix="/api/v2")
+        api2 = Api(api_bp2, prefix="/v2")
         api1.add_resource(SampleResource)
         api2.add_resource(SampleResource)
         api2.add_resource(SampleResource2)
@@ -61,6 +61,7 @@ class BlueprintApiTestCase(BaseTestCase):
         response = self.client.get("/api/v1/samples")
         self.assert200(response)
         response = self.client.get("/api/v2/samples2")
+        response = self.client.get("/api/v2/schema")
         self.assert200(response)
         response = self.client.get("/api/v2/samples2")
         self.assert200(response)
@@ -87,4 +88,5 @@ class BlueprintApiTestCase(BaseTestCase):
         response = self.client.get("/api/v1/samples/2")
         self.assert200(response)
         response = self.client.get("/api/v2/samples/1")
+        assert response.json['$uri'] == "/api/v2/samples/1"
         self.assert200(response)

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -1,18 +1,29 @@
 from flask import Blueprint
-from flask_potion import Api
+from flask_potion import Api, fields
 from flask_potion.contrib.memory.manager import MemoryManager
 from flask_potion.resource import ModelResource
 from tests import BaseTestCase
 
 
+class SampleResource(ModelResource):
+    class Schema:
+        name = fields.String()
+
+    class Meta:
+        name = "samples"
+        model = "samples"
+        manager = MemoryManager
+
+
+class SampleResource2(ModelResource):
+    class Meta:
+        name = "samples2"
+        model = "samples2"
+        manager = MemoryManager
+
+
 class BlueprintApiTestCase(BaseTestCase):
     def test_api_blueprint(self):
-        class SampleResource(ModelResource):
-            class Meta:
-                name = "samples"
-                model = "samples"
-                manager = MemoryManager
-
         api_bp = Blueprint("potion_blueprint", __name__.split(".")[0])
         api = Api(api_bp)
         api.add_resource(SampleResource)
@@ -20,4 +31,50 @@ class BlueprintApiTestCase(BaseTestCase):
         # Register Blueprint
         self.app.register_blueprint(api_bp)
         response = self.client.get("/samples")
+        self.assert200(response)
+
+    def test_api_blueprint_w_prefix(self):
+        api_bp = Blueprint("potion_blueprint", __name__.split(".")[0])
+        api = Api(api_bp, prefix="/api/v1")
+        api.add_resource(SampleResource)
+
+        # Register Blueprint
+        self.app.register_blueprint(api_bp)
+        response = self.client.get("/api/v1/samples")
+        self.assert200(response)
+
+    def test_multiple_blueprints(self):
+        # Create Blueprints
+        api_bp1 = Blueprint("potion1", __name__.split(".")[0])
+        api_bp2 = Blueprint("potion2", __name__.split(".")[0])
+
+        # Create Api objects, add resources, and register blueprints with app
+        api1 = Api(api_bp1, prefix="/api/v1")
+        api2 = Api(api_bp2, prefix="/api/v2")
+        api1.add_resource(SampleResource)
+        api2.add_resource(SampleResource)
+        api2.add_resource(SampleResource2)
+        self.app.register_blueprint(api_bp1)
+        self.app.register_blueprint(api_bp2)
+
+        # Test both endpoints
+        response = self.client.get("/api/v1/samples")
+        self.assert200(response)
+        response = self.client.get("/api/v2/samples2")
+        self.assert200(response)
+        response = self.client.get("/api/v2/samples2")
+        self.assert200(response)
+
+        # Test that endpoints are linked to same resource
+        response = self.client.post('/api/v1/samples', data={
+            "name": "to_v1"
+        })
+        self.assert200(response)
+        response = self.client.post('/api/v2/samples', data={
+            "name": "to_v2"
+        })
+        self.assert200(response)
+        response = self.client.get("/api/v1/samples/2")
+        self.assert200(response)
+        response = self.client.get("/api/v2/samples/1")
         self.assert200(response)

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, json
 from flask_potion import Api, fields
 from flask_potion.contrib.memory.manager import MemoryManager
 from flask_potion.resource import ModelResource
@@ -64,6 +64,16 @@ class BlueprintApiTestCase(BaseTestCase):
         self.assert200(response)
         response = self.client.get("/api/v2/samples2")
         self.assert200(response)
+
+        # Test that we have two prefix'd schemas
+        response = self.client.get("/api/v1/schema")
+        self.assert200(response)
+        v1_schema = json.loads(response.data)
+        response = self.client.get("/api/v2/schema")
+        self.assert200(response)
+        v2_schema = json.loads(response.data)
+        assert v1_schema != v2_schema
+        assert v1_schema["properties"]["samples"] == v2_schema["properties"]["samples"]
 
         # Test that endpoints are linked to same resource
         response = self.client.post('/api/v1/samples', data={


### PR DESCRIPTION
All of the tests should pass, and I've tested moving an app from using Potion w/o Blueprints to Blueprints with no apparent adverse effects.

**Note**: One change here is that `Api.__init__` now joins unnamed routes with `_` rather than `.` (see https://github.com/refgenomics/potion/blob/blueprints/flask_potion/__init__.py#L159-L162) if the `Api` is initialized with a Blueprint. This should potentially be simplified to always use `_` (`.` does not work with Blueprints).

**Caveats**: I have _not_ experimented with registering the same Blueprint multiple times (and if that has any unintended consequences) or registering multiple Blueprints (which this comment indicates may require a few changes https://github.com/biosustain/potion/blob/master/flask_potion/__init__.py#L83).

Closes #12.

@lyschoening – would appreciate your review and any further suggested changes.