### PR TITLE
Pass **kwargs through in PrincipalMixin._query() to wrapped manager

### DIFF
--- a/flask_potion/contrib/principals/__init__.py
+++ b/flask_potion/contrib/principals/__init__.py
@@ -175,8 +175,8 @@ class PrincipalMixin(object):
 
         return self._query_filter(query, self._or_expression(expressions))
 
-    def _query(self):
-        query = super(PrincipalMixin, self)._query()
+    def _query(self, **kwargs):
+        query = super(PrincipalMixin, self)._query(**kwargs)
 
         read_permission = self._permissions['read']
         query = self._query_filter_permission(query, read_permission)


### PR DESCRIPTION
This allows having a custom Manager that makes use of various `kwargs` in its query method, e.g., the `ArchiveManager` from the [Advanced Recipes section of the docs](http://potion.readthedocs.org/en/latest/recipes.html) that requires a custom `source` argument.