### PR TITLE
sqlalchemy.dialects.postgresql.UUID support 

### DIFF
--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -92,6 +92,8 @@ class SQLAlchemyManager(RelationalManager):
         if isinstance(column.type, postgresql.ARRAY):
             field_class = fields.Array
             args = (fields.String,)
+        elif isinstance(column.type, postgresql.UUID):
+            field_class = fields.UUID
         elif isinstance(column.type, String) and column.type.length:
             field_class = fields.String
             kwargs = {'max_length': column.type.length}

--- a/flask_potion/fields.py
+++ b/flask_potion/fields.py
@@ -43,7 +43,7 @@ class Raw(Schema):
         :return: new schema updated for field `nullable`, `title`, `description` and `default` attributes.
         """
         schema = dict(schema)
-        
+
         if self.io == "r" and "r" in io:
             schema["readOnly"] = True
 
@@ -432,6 +432,18 @@ class String(Raw):
                 schema[k] = v
 
         super(String, self).__init__(schema, **kwargs)
+
+
+class UUID(String):
+    """
+    A field for the postgres UUID field
+    """
+    url_rule_converter = 'string'
+    UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+    def __init__(self, **kwargs):
+        super(UUID, self).__init__(min_length=36, max_length=36, pattern=self.UUID_REGEX, **kwargs)
+
 
 try:
     from datetime import timezone

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 from unittest import TestCase
+from uuid import uuid4
 import unittest
 from datetime import datetime, date
 from werkzeug.exceptions import BadRequest
@@ -168,6 +169,27 @@ class FieldsTestCase(TestCase):
 
         self.assertEqual(datetime(2009, 2, 13, 23, 16, 40, 0, timezone.utc), fields.DateTime().convert({"$date": 1234567000000}))
         self.assertEqual({"$date": 1329177600000}, fields.DateTime().format(datetime(2012, 2, 14, 0, 0, 0, 0, timezone.utc)))
+
+    def test_uuid_schema(self):
+        self.assertEqual({
+                            "type": "string",
+                            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+                            "minLength": 36,
+                            "maxLength": 36
+                         }, fields.UUID().response)
+
+    def test_uuid_convert(self):
+        with self.assertRaises(ValidationError):
+            fields.UUID().convert(123456)
+
+        with self.assertRaises(ValidationError):
+            fields.UUID().convert("123456")
+
+        with self.assertRaises(ValidationError):
+            fields.UUID().convert("abcdefghijklmnopqrstuvwxyz")
+
+        uuid = str(uuid4())
+        self.assertEqual(uuid, fields.UUID().convert(uuid))
 
     def test_string_schema(self):
         self.assertEqual({


### PR DESCRIPTION
Introducing the postgres.UUID field support
PR to get https://github.com/biosustain/potion/issues/67 solved