### PR TITLE
Apply Api decorators to the main schema endpoint by default

### DIFF
--- a/flask_potion/__init__.py
+++ b/flask_potion/__init__.py
@@ -187,6 +187,8 @@ class Api(object):
         view = self.output(view_func)
 
         if self.app:
+            for decorator in self.decorators:
+                view = decorator(view)
             self.app.add_url_rule(rule, view_func=view, endpoint=endpoint, methods=methods)
         else:
             self.views.append((route, resource, view, endpoint, methods))


### PR DESCRIPTION
Apply Api decorators to the main schema endpoint by default.
Configure with environmental variable `POTION_DECORATE_SCHEMA`.