### PR TITLE
fix: check to avoid BinaryExpression raising `TypeError: Boolean valu…

### DIFF
--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -234,10 +234,16 @@ class SQLAlchemyManager(RelationalManager):
 
     def update(self, item, changes, commit=True):
         session = self._get_session()
-        actual_changes = {
-            key: value for key, value in changes.items()
-            if get_value(key, item, None) != value
-        }
+
+        actual_changes = dict()
+
+        for key, value in changes.items():
+            if value is None:
+                if get_value(key, item, None) is not None:
+                    actual_changes[key] = value
+
+            elif get_value(key, item, None) != value:
+                actual_changes[key] = value
 
         try:
             before_update.send(self.resource, item=item, changes=actual_changes)


### PR DESCRIPTION
fix: check to avoid BinaryExpression raising `TypeError: Boolean value of this clause is not defined`

When updating a value to NULL, the expression `get_value('location', item, None) != value` evaluates to `get_value('location', item, None) != None`.
The result, in case the value in db isn't NULL, is a ` IS NOT NULL` BinaryExpression. 

As documented in [here](http://docs.sqlalchemy.org/en/latest/changelog/migration_06.html#expression-language-changes), under such circumstances, using <class 'sqlalchemy.sql.elements.BinaryExpression'> as python operator raises `TypeError: Boolean value of this clause is not defined`.

