### PR TITLE
Sort instances query stably, if applicable to underlying DB implementation

### DIFF
--- a/flask_potion/manager.py
+++ b/flask_potion/manager.py
@@ -295,9 +295,7 @@ class RelationalManager(Manager):
             expressions = [self._expression_for_condition(condition) for condition in where]
             query = self._query_filter(query, self._and_expression(expressions))
 
-        if sort:
-            query = self._query_order_by(query, sort)
-
+        query = self._query_order_by(query, sort)
         return query
 
     def first(self, where=None, sort=None):


### PR DESCRIPTION
~I'm not 100% thrilled by the naming/implementation here (happy to take suggestions @lyschoening), but~ the current Flask-Potion code can lead to odd bugs for databases that do not guarantee the return order for queries without an `ORDER BY` clause (e.g., Postgres).

Specifically, we were seeing issues where we'd get duplicate records in the paginated results. The underlying issue is (depending on one's perspective) either a bug or (under/mis)documentation in Flask-SQLAlchemy's `paginate` method on the query.

This PR fixes this for the `RelationalManager` by ordering by the primary key if no other order by clause is provided. 

_Note that it may be necessary to also add the primary key to the order clause in the general `_query_order_by` call for Postgres. I'll try to investigate this more tomorrow Pacific time._