### PR TITLE
Handle integrity error on delete

### DIFF
--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -235,7 +235,7 @@ class SQLAlchemyManager(RelationalManager):
                     raise DuplicateKey(detail=e.orig.diag.message_detail)
 
             if current_app.debug:
-                raise BackendConflict(debug_info=dict(statement=e.statement, params=e.params))
+                raise BackendConflict(debug_info=dict(exception_message=str(e), statement=e.statement, params=e.params))
             raise BackendConflict()
 
         after_create.send(self.resource, item=item)
@@ -266,7 +266,7 @@ class SQLAlchemyManager(RelationalManager):
                     raise DuplicateKey(detail=e.orig.diag.message_detail)
 
             if current_app.debug:
-                raise BackendConflict(debug_info=dict(statement=e.statement, params=e.params))
+                raise BackendConflict(debug_info=dict(exception_message=str(e), statement=e.statement, params=e.params))
             raise BackendConflict()
 
         after_update.send(self.resource, item=item, changes=actual_changes)
@@ -284,7 +284,7 @@ class SQLAlchemyManager(RelationalManager):
             session.rollback()
 
             if current_app.debug:
-                raise BackendConflict(debug_info=dict(statement=e.statement, params=e.params))
+                raise BackendConflict(debug_info=dict(exception_message=str(e), statement=e.statement, params=e.params))
             raise BackendConflict()
 
         session = self._get_session()

--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -287,10 +287,6 @@ class SQLAlchemyManager(RelationalManager):
                 raise BackendConflict(debug_info=dict(exception_message=str(e), statement=e.statement, params=e.params))
             raise BackendConflict()
 
-        session = self._get_session()
-        session.delete(item)
-        session.commit()
-
         after_delete.send(self.resource, item=item)
 
     def relation_instances(self, item, attribute, target_resource, page=None, per_page=None):

--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm.collections import InstrumentedList
 from sqlalchemy.orm.exc import NoResultFound
 
 from flask_potion import fields
-from flask_potion.contrib.alchemy.filters import FILTER_NAMES, FILTERS_BY_TYPE, SQLAlchemyBaseFilter
+from flask_potion.contrib.alchemy.filters import FILTER_NAMES, FILTERS_BY_TYPE
 from flask_potion.exceptions import ItemNotFound, DuplicateKey, BackendConflict
 from flask_potion.instances import Pagination
 from flask_potion.manager import RelationalManager


### PR DESCRIPTION
-Fix SqlAlchemy manager not taking care of handling Integrity Error on delete. (rollback the session and return a nice message to the client)
- The debug message returned to the client doesn't include the exception message. This is fixed.
