### PR TITLE
Added status_code parameter to route and tests

### DIFF
--- a/flask_potion/routes.py
+++ b/flask_potion/routes.py
@@ -124,7 +124,8 @@ class Route(object):
                  description=None,
                  schema=None,
                  response_schema=None,
-                 format_response=True):
+                 format_response=True,
+                 status_code=None):
         self.rel = rel
         self.rule = rule
         self.method = method
@@ -135,6 +136,7 @@ class Route(object):
 
         self.view_func = view_func
         self.format_response = format_response
+        self.status_code = status_code
 
         annotations = getattr(view_func, '__annotations__', None)
 
@@ -267,6 +269,10 @@ class Route(object):
                 args += (request_schema.parse_request(request),)
 
             response = view_func(instance, *args, **kwargs)
+
+            if not isinstance(response, tuple) and self.status_code:
+                response = (response, self.status_code)
+
             # TODO add 'describedBy' link header if response schema is a ToOne/ToMany/Instances field.
             if response_schema is None or not self.format_response:
                 return response

--- a/flask_potion/routes.py
+++ b/flask_potion/routes.py
@@ -125,7 +125,7 @@ class Route(object):
                  schema=None,
                  response_schema=None,
                  format_response=True,
-                 status_code=None):
+                 success_code=None):
         self.rel = rel
         self.rule = rule
         self.method = method
@@ -136,7 +136,7 @@ class Route(object):
 
         self.view_func = view_func
         self.format_response = format_response
-        self.status_code = status_code
+        self.success_code = success_code
 
         annotations = getattr(view_func, '__annotations__', None)
 
@@ -270,8 +270,8 @@ class Route(object):
 
             response = view_func(instance, *args, **kwargs)
 
-            if not isinstance(response, tuple) and self.status_code:
-                response = (response, self.status_code)
+            if not isinstance(response, tuple) and self.success_code:
+                response = (response, self.success_code)
 
             # TODO add 'describedBy' link header if response schema is a ToOne/ToMany/Instances field.
             if response_schema is None or not self.format_response:

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -38,8 +38,8 @@ class RouteTestCase(BaseTestCase):
             "title": "foo"
         }, route.schema_factory(Resource))
 
-    def test_route_status(self):
-        route = Route.GET(status_code=201, rule='/test')(lambda *args, **kwargs: None)
+    def test_route_success_code(self):
+        route = Route.GET(success_code=201, rule='/test')(lambda *args, **kwargs: None)
         view = route.view_factory('', Resource)
 
         self.assertEqual((None, 201), view())
@@ -284,9 +284,9 @@ class ResourceTestCase(BaseTestCase):
         response = self.client.get("/foo/unauthorize-decorator")
         self.assert401(response)
 
-    def test_route_status(self):
+    def test_route_success_code(self):
         class FooResource(Resource):
-            @Route.GET(status_code=201)
+            @Route.GET(success_code=201)
             def foo(self):
                 return 'foo'
 

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -38,6 +38,12 @@ class RouteTestCase(BaseTestCase):
             "title": "foo"
         }, route.schema_factory(Resource))
 
+    def test_route_status(self):
+        route = Route.GET(status_code=201, rule='/test')(lambda *args, **kwargs: None)
+        view = route.view_factory('', Resource)
+
+        self.assertEqual((None, 201), view())
+
 
 class ResourceTestCase(BaseTestCase):
     def test_potion_resource(self):
@@ -277,6 +283,24 @@ class ResourceTestCase(BaseTestCase):
 
         response = self.client.get("/foo/unauthorize-decorator")
         self.assert401(response)
+
+    def test_route_status(self):
+        class FooResource(Resource):
+            @Route.GET(status_code=201)
+            def foo(self):
+                return 'foo'
+
+            class Meta:
+                name = 'foo'
+
+        api = Api(self.app)
+        api.add_resource(FooResource)
+
+        foo = self.app
+
+        response = self.client.get("/foo/foo")
+        self.assertEqual(201, response.status_code)
+        self.assertEqual('foo', response.json)
 
     def test_route_disabling(self):
 


### PR DESCRIPTION
In a recent project I found myself redefining the default routes (`read`, `create`, etc) just to change the `status_code`, figured it could be helpful to have an option in `Route` to set it.