### PR TITLE
Enabling sort_attribute

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -19,10 +19,6 @@ for the resource.
 
 :class:`ModelResource` is written for create, read, update, delete actions on collections of items matching the resource schema.
 
-A data store connection is maintained by a :class:`manager.Manager` instance.
-The manager class can be specified in ``Meta.manager``; if no manager is specified, ``Api.default_manager`` is used.
-Managers are configured through attributes in ``Meta``. Most managers expect a *model* to be defined under ``Meta.model``.
-
 .. autoclass:: ModelResource
     :members:
 


### PR DESCRIPTION
In a project I did recently, I needed to change the default sort, I saw that this attribute existed in the `Meta` class for `ModelResource`, but wasn't being used.

This PR is an attempt of enabling it for usage.