### PR TITLE
Fix a logical error deciding whether to return a patchable schema.

### DIFF
--- a/flask_potion/fields.py
+++ b/flask_potion/fields.py
@@ -717,7 +717,7 @@ class Inline(Raw, ResourceBound):
                     return {"$ref": "#"}
                 return {"$ref": self.target.routes["describedBy"].rule_factory(self.target)}
 
-            if not not self.patchable:
+            if not self.patchable:
                 return _response_schema()
             else:
                 return _response_schema(), self.target.schema.patchable.update

--- a/tests/test_model_resource.py
+++ b/tests/test_model_resource.py
@@ -85,3 +85,32 @@ class ModelResourceTestCase(BaseTestCase):
         foo.bind(BarResource)
 
         self.assertEqual({'$ref': '/foo/schema'}, foo.response)
+
+    def test_schema_io_create_flag(self):
+
+        class FooResource(ModelResource):
+            class Schema:
+                name = fields.String()
+                slug = fields.String(io="cr")
+
+            class Meta:
+                name = "foo"
+
+        self.api.add_resource(FooResource)
+        data, code, headers = FooResource().described_by()
+        [create_link] = [
+            link for link in data['links'] if link['rel'] == 'create']
+        [update_link] = [
+            link for link in data['links'] if link['rel'] == 'update']
+        self.assertEqual({'$ref': '#'}, create_link['schema'])
+        self.assertEqual({
+                             "type": "object",
+                             "additionalProperties": False,
+                             "properties": {
+                                 "name": {
+                                     "type": "string"
+                                 }
+                             }
+                         }, update_link["schema"])
+        self.assertEqual(
+            ["$uri", "name", "slug"],  sorted(data["properties"].keys()))


### PR DESCRIPTION
This partly fixes issue #98, where a field that has io="cr" wouldn't
show up in the "create" schema.