### PR TITLE
Added support for giving multiple decorators to a route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ nosetests.xml
 .project
 .pydevproject
 
-# PyCharm
+# Editors
 .idea
+.vscode
 
 *.db

--- a/flask_potion/resource.py
+++ b/flask_potion/resource.py
@@ -106,7 +106,8 @@ class Resource(six.with_metaclass(ResourceMeta, object)):
     exclude_routes         ``()``                          A list of strings; any routes --- including inherited routes --- whose ``Route.relation``
                                                            match one of these string is omitted from the resource.
     route_decorators       ``{}``                          A dictionary of decorators to apply to routes in the resource.
-                                                           The keys must match the ``Route.relation`` attribute.
+                                                           The keys must match the ``Route.relation`` attribute. The values can be
+                                                           decorators or lists of decorators.
     exclude_fields         ``()``                          A list of fields that should not be imported from the `model`.
     required_fields        ``()``                          Fields that are automatically imported from the model are automatically
                                                            required if their columns are not `nullable` and do not have a `default`.

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -260,17 +260,23 @@ class ResourceTestCase(BaseTestCase):
             def unauthorize_decorator(self):
                 return 'normal'
 
+            @Route.GET
+            def multiple_decorators(self):
+                return 'normal'
+
             class Meta:
                 name = 'foo'
                 title = 'Foo bar'
                 route_decorators = {
                     'readSimpleDecorator': denormalize,
-                    'readUnauthorizeDecorator': unauthorize
+                    'readUnauthorizeDecorator': unauthorize,
+                    'readMultipleDecorators': [denormalize] * 2
                 }
 
         self.assertEqual('normal', FooResource().no_decorator())
         self.assertEqual('normal', FooResource().simple_decorator())
         self.assertEqual('normal', FooResource().unauthorize_decorator())
+        self.assertEqual('normal', FooResource().multiple_decorators())
 
         api = Api(self.app)
         api.add_resource(FooResource)
@@ -280,6 +286,9 @@ class ResourceTestCase(BaseTestCase):
 
         response = self.client.get("/foo/simple-decorator")
         self.assertEqual('not normal', response.json)
+
+        response = self.client.get("/foo/multiple-decorators")
+        self.assertEqual('not not normal', response.json)
 
         response = self.client.get("/foo/unauthorize-decorator")
         self.assert401(response)


### PR DESCRIPTION
In a current project I'm working on, we need to decorate a few routes multiple times, I subclassed `Api` and changed the `add_route` method, but thought it useful that the functionality be in potion already.