### PR TITLE
Nullable is not required

### DIFF
--- a/flask_potion/schema.py
+++ b/flask_potion/schema.py
@@ -238,21 +238,20 @@ class FieldSet(Schema, ResourceBound):
             if key in result:
                 continue
 
-            value = None
-
             try:
                 value = object_[key]
-                value = field.convert(value, validate=False)
             except KeyError:
                 if patchable:
                     continue
 
                 if field.default is not None:
                     value = field.default
-                elif field.nullable:
+                elif field.nullable and key in self.required and not strict:
                     value = None
-                elif key not in self.required and not strict:
-                    value = None
+                else:
+                    continue
+            else:
+                value = field.convert(value, validate=False)
 
             result[field.attribute or key] = value
         return result

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import TestCase
 from flask import Flask, request, Request
 from flask_potion import fields, Resource
@@ -84,19 +85,22 @@ class SchemaTestCase(TestCase):
                                  'status': 400
                              }, cx.exception.as_dict())
 
-
+    @unittest.SkipTest
     def test_schema_class_parse_request(self):
         pass
 
+    @unittest.SkipTest
     def test_schema_class_format_response(self):
         pass
 
+    @unittest.SkipTest
     def test_fieldset_schema(self):
         pass
 
     def test_fieldset_rebind(self):
         class FooResource(Resource):
             pass
+
         class BarResource(Resource):
             pass
 
@@ -169,5 +173,6 @@ class SchemaTestCase(TestCase):
 
         self.assertEqual({"name", "secret"}, set(fs.create['required']))
 
+    @unittest.SkipTest
     def test_fieldset_format_response(self):
         pass

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -176,3 +176,74 @@ class SchemaTestCase(TestCase):
     @unittest.SkipTest
     def test_fieldset_format_response(self):
         pass
+
+    def test_field_required_and_nullable_without_default_combination(self):
+
+        field_set = FieldSet(
+            {'a': fields.String(nullable=True)},
+            required_fields=('a',)
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        self.assertEqual(field_set.convert({'a': None}), {'a': None})
+        with self.assertRaises(ValidationError):
+            field_set.convert({})
+
+    def test_field_required_and_non_nullable_without_default_combination(self):
+
+        field_set = FieldSet(
+            {'a': fields.String()},
+            required_fields=('a',)
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        with self.assertRaises(ValidationError):
+            field_set.convert({'a': None})
+        with self.assertRaises(ValidationError):
+            field_set.convert({})
+
+    def test_field_required_and_nullable_with_default_combination(self):
+
+        field_set = FieldSet(
+            {'a': fields.String(nullable=True, default='default')},
+            required_fields=('a',)
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        self.assertEqual(field_set.convert({'a': None}), {'a': None})
+        self.assertEqual(field_set.convert({'a': 'default'}), {'a': 'default'})
+
+    def test_field_required_and_non_nullable_with_default_combination(self):
+
+        field_set = FieldSet(
+            {'a': fields.String(default='default')},
+            required_fields=('a',)
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        with self.assertRaises(ValidationError):
+            field_set.convert({'a': None})
+        self.assertEqual(field_set.convert({'a': 'default'}), {'a': 'default'})
+
+    def test_field_non_required_nullable_without_default(self):
+        field_set = FieldSet(
+            {'a': fields.String(nullable=True)},
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        self.assertEqual(field_set.convert({'a': None}), {'a': None})
+        self.assertEqual(field_set.convert({}), {})
+
+    def test_field_non_required_non_nullable_without_default(self):
+        field_set = FieldSet(
+            {'a': fields.String()},
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        with self.assertRaises(ValidationError):
+            field_set.convert({'a': None})
+        with self.assertRaises(ValidationError):
+            field_set.convert({})
+
+    def test_field_non_required_non_nullable_with_default(self):
+        field_set = FieldSet(
+            {'a': fields.String(default='default')},
+        )
+        self.assertEqual(field_set.convert({'a': 'a'}), {'a': 'a'})
+        with self.assertRaises(ValidationError):
+            field_set.convert({'a': None})
+        self.assertEqual(field_set.convert({'a': 'default'}), {'a': 'default'})


### PR DESCRIPTION
Avoid transmitting `None` values when not necessary
    
Consider a nullable field, not required without default, it shouldn't be given as `None` if absent.
This is per definition an optional field, and should stay out of list of given input values if user did so.
    
This is useful to distinguish omitted fields from the ones given by users.