### PR TITLE
Requires werkzeug >= 0.15 during test execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'Flask-MongoEngine>=0.7.1',
     'peewee==2.*',
     'nose>=1.1.2',
+    'werkzeug>=0.15.0',
 ]
 
 setup(

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -64,7 +64,7 @@ class ErrorMessagesTestCase(BaseTestCase):
         response = self.client.get('/prefix/error/missing')
         self.assert404(response)
         self.assertEqual({
-            "message": "The requested URL was not found on the server.  If you entered "
+            "message": "The requested URL was not found on the server. If you entered "
                         "the URL manually please check your spelling and try again.",
             "status": 404
         }, response.json)


### PR DESCRIPTION
Because it fixes NotFound Error message