### PR TITLE
Use xenial build environment to have python3.7 available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 services:
   - mongodb
 language: python


### PR DESCRIPTION
Fixes for the tests to bring explicit support for python3.7 are coming soon.